### PR TITLE
Added automatic match starting

### DIFF
--- a/chatbot.lua
+++ b/chatbot.lua
@@ -212,6 +212,7 @@ local function on_console_command(event)
     if (cmd == "shout" or cmd == "s") and player and param then
         local chatmsg = "[shout] " .. player.name .. " (" .. player.force.name .. "): " .. param
         Server.to_discord_player_chat(chatmsg)
+        return
     elseif not player.admin or not commands[cmd] then
         return
     end

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -333,7 +333,7 @@ function Public.share_chat(event)
 		game.forces.spectator.print(msg, color)
 	end
 
-	if global.tournament_mode and not player.admin then return end
+	if global.tournament_mode then return end
 
 	--Skip messages that would spoil coordinates from spectators and don't send gps coord to discord
 	local a, b = string_find(event.message, "gps=", 1, false)

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -256,6 +256,12 @@ function Public.create_main_gui(player)
 		local b = t.add  { type = "sprite-button", name = "bb_view_players", caption = "Playerlist" }
 	end
 
+	--Tournament
+
+	if not is_spec then
+		t.add{type = "sprite-button", name = "ready", caption = "Ready"}
+		t.add{type = "sprite-button", name = "reroll", caption = "Reroll", enabled = false}
+	end
 
 	local b_width = is_spec and 97 or 86
 	-- 111 when prod_spy button will be there
@@ -346,7 +352,9 @@ function join_team(player, force_name, forced_join, auto_join)
 	player.teleport(pos)
 	player.force = game.forces[force_name]
 	player.character.destructible = true
-	game.permissions.get_group("Default").add_player(player)
+	if not global.match_running then
+		game.permissions.get_group("frozen").add_player(player)
+	end
 	if not forced_join then
 		local c = player.force.name
 		if global.tm_custom_name[player.force.name] then c = global.tm_custom_name[player.force.name] end
@@ -484,6 +492,17 @@ local function on_gui_click(event)
 	if name == "bb_view_players" then
 		global.bb_view_players[player.name] = true
 		Public.create_main_gui(player)
+	end
+	if name == "ready" then
+		game.print(player.name .. " is ready!", {0,250,0})
+		global.players_ready[player.force.name] = true
+		if global.training_mode then
+			global.match_running = true
+			return
+		end
+		if global.players_ready[Tables.enemy_team_of[player.force.name]] then
+			global.match_running = true
+		end
 	end
 end
 

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -67,6 +67,24 @@ function Public.initial_setup()
 	}
 	for _, d in pairs(defs) do p.set_allows_action(d, true) end
 
+	-- for freezing single players
+	p = game.permissions.create_group("frozen")
+	for action_name, _ in pairs(defines.input_action) do
+		p.set_allows_action(defines.input_action[action_name], false)
+	end
+	defs = {
+		defines.input_action.write_to_console,
+		defines.input_action.gui_click,
+		defines.input_action.gui_selection_state_changed,
+		defines.input_action.gui_checked_state_changed	,
+		defines.input_action.gui_elem_changed,
+		defines.input_action.gui_text_changed,
+		defines.input_action.gui_value_changed,
+		defines.input_action.edit_permission_group,
+	}	
+	for _, d in pairs(defs) do p.set_allows_action(d, true) end
+
+
 	global.gui_refresh_delay = 0
 	global.game_lobby_active = true
 	global.bb_debug = false
@@ -129,7 +147,7 @@ function Public.draw_structures()
 	Terrain.generate_additional_rocks(surface)
 	Terrain.generate_silo(surface)
 	Terrain.draw_spawn_circle(surface)
-	--Terrain.generate_spawn_goodies(surface)
+	Terrain.fill_starter_chests(surface)
 end
 
 function Public.tables()
@@ -214,12 +232,12 @@ function Public.tables()
 	global.reanim_chance = {}
 	
 	global.match_countdown = 9 --EVL time of the countdown in seconds before match starts (unpause will have a 3 seconds countdown)
-
+	global.players_ready = {["north"] = false, ["south"] = false}	--for tournament
+	global.freeze_players = true 	--tournament, just to freeze biters before the start. Doesn't affect players
 	fifo.init()
 
 	global.next_attack = "north"
 	if math.random(1,2) == 1 then global.next_attack = "south" end
-	global.starter_chests_are_filled = false
 end
 
 function Public.load_spawn()

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -236,11 +236,6 @@ local function on_tick()
 		if tick % 18000 == 0 and not(global.bb_game_won_by_team) then 
 			clear_corpses_auto(500)
 		end
-		if not(global.starter_chests_are_filled) then
-			local surface = game.surfaces[global.bb_surface_name]
-			Terrain.fill_starter_chests(surface)
-			global.starter_chests_are_filled = true
-		end
 	end
 
 	if (tick+5) % 180 == 0 then
@@ -253,7 +248,6 @@ local function on_tick()
 		if global.bb_game_won_by_team then
 			Game_over.reveal_map()
 			global.match_running = false
-            global.starter_chests_are_filled = false
 			Game_over.server_restart()
 			return
 		end
@@ -274,9 +268,14 @@ local function on_tick()
 				if player.gui.center["bbc_cdf"] then	player.gui.center["bbc_cdf"].destroy() end
 			end
 			-- EVL SET global.next_attack = "north" / "south" and global.main_attack_wave_amount=0 --DEBUG--
-			global.freeze_players = false
-			Team_manager.unfreeze_players()
-
+			
+			--tournament unfreeze
+			for k, v in pairs({"north", "south"}) do
+				for _, p in pairs(game.forces[v].players) do
+					game.permissions.get_group("Default").add_player(p)
+				end
+			end
+			global.freeze_players = false 	--unfreeze biters
 			--game.tick_paused=false --EVL Not that easy (see team_manager.lua)
 			game.speed=1 --EVL back to normal speed
 			game.print(">>>>> Players & Biters have been unfrozen !", {r = 255, g = 77, b = 77})

--- a/maps/biter_battles_v2/team_manager.lua
+++ b/maps/biter_battles_v2/team_manager.lua
@@ -175,6 +175,7 @@ local function draw_manager_gui(player)
 	
 	if global.freeze_players then
 		button = t.add({
+			enabled = false,	--for tournament
 			type = "button",
 			name = "team_manager_freeze_players",
 			caption = "Unfreeze Players",
@@ -183,6 +184,7 @@ local function draw_manager_gui(player)
 		button.style.font_color = {r = 222, g = 22, b = 22}
 	else
 		button = t.add({
+			enabled = false,	--for tournament
 			type = "button",
 			name = "team_manager_freeze_players",
 			caption = "Freeze Players",

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -797,7 +797,6 @@ function Public.fill_starter_chests(surface)
 		global.packchest2S.insert({name=_item, count=_qty})
 	end
 	global.fill_starter_chests = false
-	global.starter_chests_are_filled = true
 end
 
 return Public


### PR DESCRIPTION
Moved chest logic to init
Fixed chat sharing

### Brief description of the changes:
Changed starter chest logic to be called only once, not every tick
Changed match starting: players join teams and get frozen. After (both) clicking Ready button countdown begins and players are unfrozen
Fixed minor chat issues

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
