### PR TITLE
Tournament

### DIFF
--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -279,6 +279,7 @@ local function on_tick()
 			--game.tick_paused=false --EVL Not that easy (see team_manager.lua)
 			game.speed=1 --EVL back to normal speed
 			game.print(">>>>> Players & Biters have been unfrozen !", {r = 255, g = 77, b = 77})
+			game.reset_time_played()	--reset clock
 		end
 	end
 end


### PR DESCRIPTION
### Brief description of the changes:
Clock starts now at the actual start of the match

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
